### PR TITLE
Change external IP fetching method

### DIFF
--- a/cf-update.sh
+++ b/cf-update.sh
@@ -40,7 +40,7 @@ fi
 
 pushd ${updatedir} > /dev/null 2>&1
 
-export newip=$(dig @8.8.8.8 -t txt o-o.myaddr.l.google.com | grep "client-subnet" | grep -o "\([0-9]\{1,3\}\.\)\{3\}\([0-9]\{1,3\}\)")
+export newip=$(dig +short myip.opendns.com @resolver1.opendns.com)
 
 if [[ "${setip}" == *"connection timed out"* ]] || [ "${newip}" == "" ] || [ "${setip}" == "" ]; then
     echo Obtaining Addresses Failed. Now Exiting...


### PR DESCRIPTION
The previous command only returns the subnet of the external IP, resulting in `xx.xx.xx.0` addresses being detected (e.g. if the user is on a /24 subnet). This dig command gets the external IP from OpenDNS' resolver instead. Source: https://unix.stackexchange.com/a/81699/60685