### PR TITLE
Update cf-update.sh

### DIFF
--- a/cf-update.sh
+++ b/cf-update.sh
@@ -40,7 +40,7 @@ fi
 
 pushd ${updatedir} > /dev/null 2>&1
 
-export newip=$(dig @8.8.8.8 -t txt o-o.myaddr.l.google.com | grep "client-subnet" | grep -o "\([0-9]\{1,3\}\.\)\{3\}\([0-9]\{1,3\}\)")
+export newip=$(curl ipv4bot.whatismyipaddress.com)
 
 if [[ "${setip}" == *"connection timed out"* ]] || [ "${newip}" == "" ] || [ "${setip}" == "" ]; then
     echo Obtaining Addresses Failed. Now Exiting...


### PR DESCRIPTION
o-o.myaddr.l.google.com was reporting back the wrong IP address for me, which I believe is because the ISP I use has made the switch to IPv6. 

This API service returns only the IPv4 address and nothing else. It is fast and has been working for many years.

Could the code perhaps be updated to allow for IPv6? I have to hold my hands up and say that I have some learning to do before I could manage that.